### PR TITLE
Changed the pandas append function:

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -78,7 +78,7 @@ def xml_to_csv(soup_xml, name):
             "Investment Discretion": investmentdiscretion.text,
             "Voting Sole / Shared / None": f"{sole.text} / {shared.text} / {none.text}"
         }
-        df = df.append(row, ignore_index=True)
+        df = df._append(row, ignore_index=True)
 
 
     df.to_csv(f"{name}.csv")


### PR DESCRIPTION
The current version of pandas causes the following error when trying to enter a 10-digit CIK:

"Traceback (most recent call last):
  File "C:\Users\Sebastian\Desktop\13F\scraper.py", line 88, in <module>
    scrap_company_report(requested_cik)
  File "C:\Users\Sebastian\Desktop\13F\scraper.py", line 35, in scrap_company_report
    scrap_report_by_url(last_report, "last_report")
  File "C:\Users\Sebastian\Desktop\13F\scraper.py", line 47, in scrap_report_by_url
    xml_to_csv(soup_xml, filename)
  File "C:\Users\Sebastian\Desktop\13F\scraper.py", line 81, in xml_to_csv
    df = df.append(row, ignore_index=True)
  File "C:\Python310\lib\site-packages\pandas\core\generic.py", line 5989, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'DataFrame' object has no attribute 'append'. Did you mean: '_append"


The added underscore fixes this incompatibility problem.